### PR TITLE
Merge update 13/03/22 from main-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ You can see the script in action in this [demo video](https://www.youtube.com/wa
 
 This is the script version, a [mod version](https://steamcommunity.com/sharedfiles/filedetails/?id=2393517275) is also available on the Steam Workshop.
 
+### *This script requires CBA_A3*
+
 ### **Features:**
 - Customisable beam/debris colour
 - Damages/destroys nearby units, vehicles and buildings
@@ -73,6 +75,28 @@ ___
 
 ## Changelog
 Read below for complete changelog history.
+
+### 22/02/2022
+New features:
+- Added lethal radius and damage radius parameters to `fn_beam`.
+- Added 'Lethal radius' and 'Damage radius' sliders to 'Beam Laser Strike' and 'Orbital Bombardment' ZEN modules.
+- Infantry units within the lethal radius of the laser will now be vaporised.
+- Structures within the lethal radius of the laser now have a chance to catch fire.
+- A crater is created when the beam impacts terrain.
+- Implemented CBA settings support. The script now requires CBA.
+- Added various CBA settings to customise/disable newly added features.
+
+Effect tweaks:
+- Destroyed objects within the lethal radius no longer have damage effects to prevent large lag spikes when destroying lots of buildings.
+- Added a shockwave particle on beam impact.
+- Camera shake is now applied up to 2km away and lowers in intensity the further away the player is.
+- The bright flash on beam impact is now only shown when the player is within 2km and looking towards the impact point.
+- Camera shake, flash and blur effects are no longer shown in spectator mode or while using the Zeus interface.
+- Explosion particles are now created from the laser impact point instead of the terrain beneath it.
+
+Misc:
+- The script now checks for 'ace_medical' rather than 'ace_main' so it should work for versions of ACE that have medical functions removed.
+- Fixed a bug where the laser could sometimes get deflected in strange directions when bouncing off buildings.
 
 ### 24/11/2021
 - Fixed 'Disable beam damage' parameter for ZEN modules enabling damage instead of disabling it.

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ ___
 ## Changelog
 Read below for complete changelog history.
 
-### 22/02/2022
+### 13/03/2022
 New features:
 - Added lethal radius and damage radius parameters to `fn_beam`.
 - Added 'Lethal radius' and 'Damage radius' sliders to 'Beam Laser Strike' and 'Orbital Bombardment' ZEN modules.

--- a/description.ext
+++ b/description.ext
@@ -7,3 +7,9 @@ class CfgSounds {
     sounds[] = {};
     #include "scripts\tts_beam\cfgSounds.hpp"
 };
+
+class Extended_PreInit_EventHandlers {
+	class tts_beam_CBA_init {
+        init = "call compile preprocessFileLineNumbers 'scripts\tts_beam\functions\fn_CBASettings.sqf'";
+    };
+};

--- a/scripts/tts_beam/cfgFunctions.hpp
+++ b/scripts/tts_beam/cfgFunctions.hpp
@@ -12,6 +12,8 @@ class tts_beam
         class explosionParticles {};
         class postProcessEffects {};
         class colourFromString {};
+        class vaporise {};
+        class smoulder {};
     };
     class zen
     {

--- a/scripts/tts_beam/functions/fn_CBASettings.sqf
+++ b/scripts/tts_beam/functions/fn_CBASettings.sqf
@@ -1,0 +1,101 @@
+// EFFECTS ////////////////////////////////////////////////////////////////////////////////////////
+[
+	"tts_beam_vaporiseBodies",
+	"CHECKBOX",
+	["STR_tts_beam_settings_vaporiseBodies", "STR_tts_beam_settings_vaporiseBodies_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_effects"],
+	true,
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+[
+	"tts_beam_structureFiresEnabled",
+	"CHECKBOX",
+	["STR_tts_beam_settings_structureFiresEnabled", "STR_tts_beam_settings_structureFiresEnabled_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_effects"],
+	true,
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+[
+	"tts_beam_structureFireChance",
+	"SLIDER",
+	["STR_tts_beam_settings_structureFireChance", "STR_tts_beam_settings_structureFireChance_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_effects"],
+	[0.01, 1, 0.03, 0, true],
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+[
+	"tts_beam_structureFireMinDuration",
+	"SLIDER",
+	["STR_tts_beam_settings_structureFireDurationMin", "STR_tts_beam_settings_structureFireDurationMin_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_effects"],
+	[1, 600, 60, 0, false],
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+[
+	"tts_beam_structureFireMaxDuration",
+	"SLIDER",
+	["STR_tts_beam_settings_structureFireDurationMax", "STR_tts_beam_settings_structureFireDurationMax_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_effects"],
+	[1, 600, 120, 0, false],
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+[
+	"tts_beam_createCraters",
+	"CHECKBOX",
+	["STR_tts_beam_settings_createCraters", "STR_tts_beam_settings_createCraters_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_effects"],
+	true,
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+// CLEANUP ////////////////////////////////////////////////////////////////////////////////////////
+[
+	"tts_beam_cleanupSkeletons",
+	"CHECKBOX",
+	["STR_tts_beam_settings_cleanupSkeletons", "STR_tts_beam_settings_cleanupSkeletons_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_cleanup"],
+	false,
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+[
+	"tts_beam_cleanupSkeletonsDelay",
+	"SLIDER",
+	["STR_tts_beam_settings_cleanupSkeletonsDelay", "STR_tts_beam_settings_cleanupSkeletonsDelay_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_cleanup"],
+	[1, 600, 300, 0, false],
+	1, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;
+
+// MISC ////////////////////////////////////////////////////////////////////////////////////////
+[
+	"tts_beam_disableImpactFlash",
+	"CHECKBOX",
+	["STR_tts_beam_settings_disableImpactFlash", "STR_tts_beam_settings_disableImpactFlash_desc"],
+	["TTS Beam Laser", "STR_tts_beam_settingsCat_misc"],
+	false,
+	0, // 0 = local, 1 = global, 2 = no overwriting
+	{},
+	false
+] call CBA_fnc_addSetting;

--- a/scripts/tts_beam/functions/fn_beam.sqf
+++ b/scripts/tts_beam/functions/fn_beam.sqf
@@ -6,9 +6,11 @@
 
     Parameters:
         0: OBJECT - The object the beam is created above.
-        1: ARRAY (OPTIONAL) - Colour of the beam in format [r,g,b].
-        2: ARRAY (OPTIONAL) - Colour of dust created on impact in format [r,g,b].
-        3: BOOL (OPTIONAL) - False to disable damage and destruction of beam.
+        1: ARRAY (OPTIONAL) - Colour of the beam in format [r, g, b]. Default value is [1, 0.6, 0.2]
+        2: ARRAY (OPTIONAL) - Colour of dust created on impact in format [r,g,b]. Default value is [0.3, 0.27, 0.15]
+        3: BOOL (OPTIONAL) - False to disable damage and destruction of beam. Default value is true
+        4: NUMBER (OPTIONAL) - Distance in metres from beam laser impact point to deal lethal damage. Default value is 200
+        5: NUMBER (OPTIONAL) - Maximum distance from the beam laser impact point that units will take damage. Default value is 400
         
     Returns:
         NONE
@@ -17,17 +19,18 @@
 params [
     ["_target", objNull, [objNull]],
     ["_beamColour", [1,0.6,0.2], [[]]],
-    ["_debrisColour", [0.3, 0.27, 0.15], [[]]],
-    ["_isLethal", true, [true]]
+    ["_debrisColour", [0.3,0.27,0.15], [[]]],
+    ["_isLethal", true, [true]],
+    ["_killRange", 200, [0]],
+    ["_maxDamageRange", 400, [0]]
 ];
 
 // input validation
 if (isNull _target) exitWith {systemChat "Invalid position given for beam target! Exited";};
 if (count _beamColour < 3) then {_beamColour = [1,0.6,0.2]; systemChat "Invalid colour given for beam, default used instead";};
-if (count _debrisColour < 3) then {_debrisColour = [0.3, 0.27, 0.15]; systemChat "Invalid colour given for beam debris, default used instead";};
-
-private _maxKillRange = 200;
-private _maxDamageRange = 400;
+if (count _debrisColour < 3) then {_debrisColour = [0.3,0.27,0.15]; systemChat "Invalid colour given for beam debris, default used instead";};
+if (_killRange < 1) then {_killRange = 1;};
+if (_maxDamageRange < _killRange) then {_maxDamageRange = _killRange;};
 
 private _targetPos = getPosATL _target;
 
@@ -54,14 +57,24 @@ _flash spawn {sleep 0.1; deleteVehicle _this;};
 waitUntil {sleep 0.01; ((getPosATL _beamEmitter)#2 < 750)};
 _impactEmitter say3D ["tts_laser", 20000, 1, false];
 
+// angle between vector [0,0,-1] and velocity [x,y,z] == acos(-z)
+
 // wait until touching ground/near target
-waitUntil {sleep 0.01; vectorMagnitude (velocity _beamEmitter) < 20 || _beamEmitter distance _targetPos < 5 || (getPosATL _beamEmitter)#2 < 5};
+waitUntil {sleep 0.01; acos -((vectorNormalized velocity _beamEmitter)#2) > 1|| _beamEmitter distance _targetPos < 5 || (getPosATL _beamEmitter)#2 < 5};
 _impactEmitter say3D ["tts_laser_impact", 20000, 1, false];
 _impactEmitter setPosATL (getPosATL _beamEmitter);
 deleteVehicle _beamEmitter;
 
+// if the laser impacts the terrain create a crater
+private _impactPosition = getPosATL _impactEmitter;
+if (missionNamespace getVariable ["tts_beam_createCraters", true] && !surfaceIsWater _impactPosition && _impactPosition#2 < 3) then {
+    private _craterLarge = createVehicle ["Land_ShellCrater_02_extralarge_F", getPosATL _impactEmitter, [], 0, "CAN_COLLIDE"];
+    private _crater = createVehicle ["Crater", getPosATL _impactEmitter, [], 0, "CAN_COLLIDE"];
+    {_x enableSimulationGlobal false;} forEach [_craterLarge, _crater];
+};
+
 // destroy/damage any nearby units/objects/buildings
-if (isServer && _isLethal) then {[_impactEmitter, _maxKillRange, _maxDamageRange] spawn tts_beam_fnc_explosionDamage;};
+if (isServer && _isLethal) then {[_impactEmitter, _killRange, _maxDamageRange] spawn tts_beam_fnc_explosionDamage;};
 
 // explosion particles
 [_impactEmitter, _debrisColour] spawn tts_beam_fnc_explosionParticles;

--- a/scripts/tts_beam/functions/fn_explosionParticles.sqf
+++ b/scripts/tts_beam/functions/fn_explosionParticles.sqf
@@ -16,29 +16,33 @@ if (!hasInterface) exitWith {}; // dedicated server & HC should not run particle
 
 params ["_impactEmitter", "_col"];
 
+private _shockwave = "#particlesource" createVehicleLocal (getPosATL _impactEmitter);
+drop [["\A3\data_f\ParticleEffects\Universal\Refract.p3d", 1, 0, 1], "","Billboard", 1, 1, [0, 0, 0], [0, 0, 0], 17, 10, 7.9, 0, [2,1000], [[0,0,0,1],[0,0,0,0]], [0.08], 1, 0, "", "", _shockwave]; 
+deleteVehicle _shockwave;
+
 // dust wave
-_wave = "#particlesource" createVehicleLocal getPos _impactEmitter;
+private _wave = "#particlesource" createVehicleLocal (getPosATL _impactEmitter);
 _wave setParticleParams [["A3\Data_F\ParticleEffects\Universal\universal.p3d", 16, 7, 48], "", "Billboard", 1, 7, [0, 0, 0],[0, 0, 0], 0, 1.5, 1, 0, [50, 100], [[_col#0, _col#1, _col#2, 0.5], [_col#0, _col#1, _col#2, 0.5], [_col#0, _col#1, _col#2, 0.3], [_col#0, _col#1, _col#2, 0]], [1,0.5], 0.1, 1, "", "", _impactEmitter];
 _wave setParticleRandom [2, [20, 20, 20], [5, 5, 0], 0, 0, [0, 0, 0, 0.1], 0, 0];
 _wave setParticleCircle [50, [-80, -80, 2.5]];
 _wave setDropInterval 0.001;
 
 // dust cloud
-_cloud = "#particlesource" createVehicleLocal getPos _impactEmitter;
+private _cloud = "#particlesource" createVehicleLocal (getPosATL _impactEmitter);
 _cloud setParticleParams [["A3\Data_F\ParticleEffects\Universal\universal.p3d", 16, 7, 48], "", "Billboard", 1, 18, [0, 0, 0],[0, 0, 0], 0, 1.5, 1, 0, [50, 65], [[_col#0, _col#1, _col#2, 0.5], [_col#0, _col#1, _col#2, 0.5], [_col#0, _col#1, _col#2, 0.3], [_col#0, _col#1, _col#2, 0]], [1,0.5], 0.1, 1, "", "", _impactEmitter];
 _cloud setParticleRandom [2, [10, 10, 5], [10, 10, 5], 0, 0, [0, 0, 0, 0.1], 0, 0];
 _cloud setParticleCircle [50, [8, 8, 5]];
 _cloud setDropInterval 0.005;
 
 // dust tower
-_tower = "#particlesource" createVehicleLocal getPos _impactEmitter;
+private _tower = "#particlesource" createVehicleLocal (getPosATL _impactEmitter);
 _tower setParticleParams [["A3\Data_F\ParticleEffects\Universal\universal.p3d", 16, 7, 48], "", "Billboard", 1, 18, [0, 0, 0],[0, 0, 0], 0, 1.5, 1, 0, [40, 90], [[_col#0, _col#1, _col#2, 0.5], [_col#0, _col#1, _col#2, 0.5], [_col#0, _col#1, _col#2, 0.3], [_col#0, _col#1, _col#2, 0]], [1,0.5], 0.1, 1, "", "", _impactEmitter];
 _tower setParticleRandom [2, [10, 10, 5], [5, 5, 20], 0, 0, [0, 0, 0, 0.1], 0, 0];
 _tower setParticleCircle [20, [2, 2, 20]];
 _tower setDropInterval 0.01;
 
 // rocks
-_debris = "#particlesource" createVehicleLocal (getPosATL _impactEmitter);
+private _debris = "#particlesource" createVehicleLocal (getPosATL _impactEmitter);
 _debris setParticleParams [["\A3\data_f\ParticleEffects\Universal\Mud.p3d", 1, 0, 1, 1], "", "SpaceObject", 1,30,[0,0,0],[0, 0, 20], 1, 500,15,0,[2.5],[[0, 0, 0, 1]], [0.125],0, 0, "","",_impactEmitter, 0, true,0];
 _debris setParticleRandom [10,[25, 25, 0.1],[30, 30, 20],0.5,1,[0, 0, 0, 0],0,0,0,0];
 _debris setParticleCircle [0.5,[10, 10, 10]];

--- a/scripts/tts_beam/functions/fn_init.sqf
+++ b/scripts/tts_beam/functions/fn_init.sqf
@@ -11,6 +11,8 @@
         NONE
 */
 
+tts_beam_aceEnabled = isClass(configFile >> "CfgPatches" >> "ace_medical");
+
 if (isClass(configFile >> "CfgPatches" >> "tts_effects_aio")) exitWith {};
 
 [] call tts_beam_fnc_initCustomModules;

--- a/scripts/tts_beam/functions/fn_orbitalBombardment.sqf
+++ b/scripts/tts_beam/functions/fn_orbitalBombardment.sqf
@@ -23,6 +23,8 @@ params [
 	["_beamColour", [1,0.6,0.2], [[]]],
 	["_debrisColour", [0.3, 0.27, 0.15], [[]]],
 	["_isLethal", true, [true]],
+    ["_killRange", 200, [0]],
+    ["_maxDamageRange", 400, [0]],
 	["_radius", 200, [0]],
 	["_strikeCount", 5, [0]],
 	["_shotDelay", 5, [0]],
@@ -33,6 +35,8 @@ if (!isServer) exitWith {};
 
 if (count _beamColour < 3) then {_beamColour = [1,0.6,0.2]; systemChat "Invalid colour given for beam, default used instead";};
 if (count _debrisColour < 3) then {_debrisColour = [0.3, 0.27, 0.15]; systemChat "Invalid colour given for beam debris, default used instead";};
+if (_killRange < 1) then {_killRange = 1;};
+if (_maxDamageRange < _killRange) then {_maxDamageRange = _killRange;};
 if (_radius < 0) then {_radius = 0;};
 if (_strikeCount <= 0) then {_strikeCount = 1;};
 if (_shotDelay < 0.1) then {_shotDelay = 0.1};
@@ -71,7 +75,7 @@ for "_i" from 1 to _strikeCount do
 	
 	_target spawn {sleep 15; deleteVehicle _this;};
 
-	[_target, _colour, _debrisColour, _isLethal] remoteExec ["tts_beam_fnc_beam", 0, false];
+	[_target, _colour, _debrisColour, _isLethal, _killRange, _maxDamageRange] remoteExec ["tts_beam_fnc_beam", 0, false];
 
 	sleep _shotDelay;
 };

--- a/scripts/tts_beam/functions/fn_postProcessEffects.sqf
+++ b/scripts/tts_beam/functions/fn_postProcessEffects.sqf
@@ -14,27 +14,35 @@
 params ["_target"];
 
 if (!hasInterface) exitWith {}; // dedicated server & HC do not need to run post process effects
-if (player distance _target > 1000) exitWith {}; // don't play ppeffects if player is far away
+if (!isNull (findDisplay 60492) || !isNull (findDisplay 312)) exitWith {}; // if spectator/zeus interface are open don't show effects
+
+// camera shake
+if ((positionCameraToWorld [0,0,0]) distance2D _target < 2000) then {
+    private _distanceCoef = 1 - ((positionCameraToWorld [0,0,0]) distance2D _target)/2000;
+
+    enableCamShake true;
+    addCamShake [15 * _distanceCoef, 5, 12];
+};
+
+// flash
+if (!(missionNamespace getVariable ["tts_beam_disableImpactFlash", false]) && (positionCameraToWorld [0,0,0]) distance2D _target < 3000) then {
+    private _cameraDirection = getCameraViewDirection player;
+    private _dirToLaser = (positionCameraToWorld [0,0,0]) vectorFromTo (position _target);
+    
+    private _angleBetween = acos (_cameraDirection vectorDotProduct _dirToLaser);
+
+    // only show flash effect if player is looking towards the laser impact
+    if (_angleBetween < 80) then {
+        cutText ["", "WHITE OUT", 1];
+        titleCut ["", "WHITE IN", 1];
+    };
+};
 
 // blur
-[] spawn {		
-    cutText ["", "WHITE OUT", 1];
-    titleCut ["", "WHITE IN", 1];
-    "dynamicBlur" ppEffectEnable true;   
-    "dynamicBlur" ppEffectAdjust [8];   
-    "dynamicBlur" ppEffectCommit 0;     
-    "dynamicBlur" ppEffectAdjust [0.0];  
-    "dynamicBlur" ppEffectCommit 1.5;  
-    sleep 1.5;
-    "dynamicBlur" ppEffectEnable false; 
-};
-
-// shake
-[] spawn {
-    addCamShake [55, 5, 21];
-    enableCamShake false;
-    sleep 1;
-    enableCamShake true;
-    addCamShake [15, 5, 21];
-    enableCamShake false;
-};
+"dynamicBlur" ppEffectEnable true;   
+"dynamicBlur" ppEffectAdjust [8];   
+"dynamicBlur" ppEffectCommit 0;     
+"dynamicBlur" ppEffectAdjust [0.0];  
+"dynamicBlur" ppEffectCommit 1.5;  
+sleep 1.5;
+"dynamicBlur" ppEffectEnable false; 

--- a/scripts/tts_beam/functions/fn_smoulder.sqf
+++ b/scripts/tts_beam/functions/fn_smoulder.sqf
@@ -1,0 +1,62 @@
+/*
+    Author: TheTimidShade
+
+    Description:
+        Creates smouldering fire effect on the target object
+		Used when static objects are destroyed by the laser explosion
+
+    Parameters:
+		0: STRING - Type of fire to create
+        0: POSITION - Source of fire
+		1: NUMBER - How long the fire burns for
+        
+    Returns:
+        NONE
+*/
+
+if (!hasInterface) exitWith {};
+
+params [
+	["_type", "small", [""]],
+    ["_position", [0,0,0], [[]], [2,3]],
+	["_duration", 30, [0]]
+];
+
+private _fire = "#particlesource" createVehicleLocal _position;
+private _smoke = "#particlesource" createVehicleLocal _position;
+
+switch (_type) do {
+	case "small": {
+		_fire setParticleClass "IEDFlameF";
+		_smoke setParticleClass "IEDFlameS";
+	};
+	case "medium": {
+		_fire setParticleClass "MediumDestructionFire";
+		_smoke setParticleClass "MediumDestructionSmoke";
+	};
+	case "large": {
+		_fire setParticleClass "BigDestructionFire";
+		_smoke setParticleClass "BigDestructionSmoke";
+	};
+	case "skeleton": {
+		_smoke setParticleClass "SmallDestructionSmoke";
+	};
+	default { 
+		_fire setParticleClass "MediumDestructionFire";
+		_smoke setParticleClass "MediumDestructionSmoke";
+	};
+};
+
+sleep _duration;
+
+{deleteVehicle _x;} forEach [_fire, _smoke];
+
+//ObjectDestructionFire1Tiny
+//IEDMineFireStones
+//IEDMineFireStonesBig
+//SmallDestructionFire
+//SmallDestructionSmoke
+//BigDestructionFire
+//BigDestructionSmoke
+//MediumDestructionFire
+//MediumDestructionSmoke

--- a/scripts/tts_beam/functions/fn_vaporise.sqf
+++ b/scripts/tts_beam/functions/fn_vaporise.sqf
@@ -1,0 +1,83 @@
+/*
+    Author: TheTimidShade
+
+    Description:
+        Handles effects on individual objects within the lethal radius of the beam strike explosion
+
+    Parameters:
+        0: OBJECT - Object being destroyed by the beam
+        
+    Returns:
+        NONE
+*/
+
+if (!isServer) exitWith {};
+
+params [
+    ["_target", objNull, [objNull]]
+];
+
+if (isNull _target) exitWith {};
+
+// disintegrate men
+if (_target isKindOf "CAManBase") then {
+	_target setDamage 1;
+	
+	if (missionNamespace getVariable ["tts_beam_vaporiseBodies", true]) then {
+		// hide the body
+		_target hideObjectGlobal true;
+
+		// create a skeleton object
+		private _skeleton = createVehicle ["Land_HumanSkeleton_F", (getPosATL _target), [], 0, "CAN_COLLIDE"];
+		_skeleton setDir (random 360);
+		_skeleton setPosATL (getPosATL _skeleton);
+
+		// create scorch mark
+		private _scorch = createVehicle ["Land_Decal_ScorchMark_01_small_F", (getPosATL _target), [], 0, "CAN_COLLIDE"];
+		_scorch setDir (random 360);
+		_scorch setPosATL (getPosATL _scorch);
+
+		["skeleton", position _skeleton, 30 + random 30] remoteExec ["tts_beam_fnc_smoulder", 0, false];
+
+		// if cleanup is enabled, start the cleanup timer
+		if (missionNamespace getVariable ["tts_beam_cleanupSkeletons", false]) then {
+			[_skeleton, _scorch] spawn {
+				sleep (missionNamespace getVariable ["tts_beam_cleanupSkeletonsDelay", 300]);
+				{deleteVehicle _x;} forEach _this;
+			};
+		};
+	};
+};
+
+// have a chance to burn buildings/static objects
+if (_target isKindOf "Static") then {
+	_target setDamage [1, false];
+	
+	// static objects have a chance to burn when destroyed
+	if (missionNamespace getVariable ["tts_beam_structureFiresEnabled", true] && {random 1 < missionNamespace getVariable ["tts_beam_structureFireChance", 0.03]}) then {
+		private _size = sizeOf typeOf _target;
+		private _minDuration = missionNamespace getVariable ["tts_beam_structureFireMinDuration", 60];
+		private _maxDuration = missionNamespace getVariable ["tts_beam_structureFireMaxDuration", 120];
+		private _duration = _minDuration + (random (_maxDuration - _minDuration));
+		
+		private _fireType = "small";
+		
+		if (_size < 5) then {
+			_fireType = "small";
+		} else { if (_size < 10) then {
+			_fireType = "medium";
+		} else { 
+			_fireType = "large";
+		};};
+
+		// slight displacement of fire position based on object size
+		private _firePos = (position _target) getPos [random (_size/2), random 360];
+
+		[_fireType, _firePos, _duration] remoteExec ["tts_beam_fnc_smoulder", 0, false];
+	};
+};
+
+// if the object is neither a man or a building just destroy it
+if (!(_target isKindOf "CAManBase" || _target isKindOf "Static")) then {
+	_target setDamage 1;
+};

--- a/scripts/tts_beam/functions/zen/fn_zen_moduleBeamStrike.sqf
+++ b/scripts/tts_beam/functions/zen/fn_zen_moduleBeamStrike.sqf
@@ -10,30 +10,57 @@
                     ["Custom", "Red", "Orange", "Yellow", "Green", "Blue", "Cyan", "Pink", "Purple"], // return values
                     ["STR_tts_beam_moduleBeamStrike_beamColour_custom", "STR_tts_beam_moduleBeamStrike_beamColour_red", "STR_tts_beam_moduleBeamStrike_beamColour_orange", "STR_tts_beam_moduleBeamStrike_beamColour_yellow", "STR_tts_beam_moduleBeamStrike_beamColour_green", "STR_tts_beam_moduleBeamStrike_beamColour_blue", "STR_tts_beam_moduleBeamStrike_beamColour_cyan", "STR_tts_beam_moduleBeamStrike_beamColour_pink", "STR_tts_beam_moduleBeamStrike_beamColour_purple"], // labels
                     0 // element 0 is default selected
-                ]
+                ],
+                false
             ],
             ["COLOR", ["STR_tts_beam_moduleBeamStrike_customBeamColour", "STR_tts_beam_moduleBeamStrike_customBeamColour_desc"],
-                [1,0.6,0.2]
+                [1,0.6,0.2],
+                false
             ],
             ["COMBO", ["STR_tts_beam_moduleBeamStrike_debrisColour", "STR_tts_beam_moduleBeamStrike_debrisColour_desc"],
                 [ // control args
                     ["Custom", "Mud", "Snow", "Sand"], // return values
                     ["STR_tts_beam_moduleBeamStrike_beamColour_custom", "STR_tts_beam_moduleBeamStrike_debrisColour_mud", "STR_tts_beam_moduleBeamStrike_debrisColour_snow", "STR_tts_beam_moduleBeamStrike_debrisColour_sand"], // labels
                     0 // element 0 is default selected
-                ]
+                ],
+                false
             ],
             ["COLOR", ["STR_tts_beam_moduleBeamStrike_customDebrisColour", "STR_tts_beam_moduleBeamStrike_customDebrisColour_desc"],
-                [0.3,0.27,0.15]
+                [0.3,0.27,0.15],
+                false
             ],
             ["CHECKBOX", ["STR_tts_beam_moduleBeamStrike_disableBeamDamage", "STR_tts_beam_moduleBeamStrike_disableBeamDamage_desc"],
                 [ // control args
                     false // default state
-                ]
+                ],
+                false
+            ],
+            ["SLIDER:RADIUS", ["STR_tts_beam_moduleBeamStrike_lethalRadius", "STR_tts_beam_moduleBeamStrike_lethalRadius_desc"],
+                [ // control args
+                    1, // min
+                    2000, // max
+                    200, // default
+                    0, // decimals
+                    _position, // radius center position
+                    [1, 0, 0, 0.5] // radius colour
+                ],
+                false
+            ],
+            ["SLIDER:RADIUS", ["STR_tts_beam_moduleBeamStrike_damageRadius", "STR_tts_beam_moduleBeamStrike_damageRadius_desc"],
+                [ // control args
+                    1, // min
+                    2000, // max
+                    400, // default
+                    0, // decimals
+                    _position, // radius center position
+                    [0, 1, 0, 0.5] // radius colour
+                ],
+                false
             ]
         ],
         { // code run on dialog closed (only run if OK is clicked)
             params ["_dialogResult", "_args"];
-            _dialogResult params ["_beamColourPreset", "_customBeamColour", "_debrisColourPreset", "_customDebrisColour", "_disableDamage"];
+            _dialogResult params ["_beamColourPreset", "_customBeamColour", "_debrisColourPreset", "_customDebrisColour", "_disableDamage", "_lethalRadius", "_damageRadius"];
             _args params ["_position"];
 
             private _beamColour = [];
@@ -52,7 +79,7 @@
 
             private _beamTarget = "Land_HelipadEmpty_F" createVehicle _position;
 
-            [_beamTarget, _beamColour, _debrisColour, !_disableDamage] remoteExec ["tts_beam_fnc_beam", 0, false]; // fire beam
+            [_beamTarget, _beamColour, _debrisColour, !_disableDamage, _lethalRadius, _damageRadius] remoteExec ["tts_beam_fnc_beam", 0, false]; // fire beam
 
             _beamTarget spawn {sleep 60; deleteVehicle _this;}; // wait and cleanup target pos
         }, {}, [_position] // args

--- a/scripts/tts_beam/functions/zen/fn_zen_moduleOrbitalBombardment.sqf
+++ b/scripts/tts_beam/functions/zen/fn_zen_moduleOrbitalBombardment.sqf
@@ -30,6 +30,28 @@
                     false // default state
                 ]
             ],
+            ["SLIDER:RADIUS", ["STR_tts_beam_moduleBeamStrike_lethalRadius", "STR_tts_beam_moduleBeamStrike_lethalRadius_desc"],
+                [ // control args
+                    1, // min
+                    2000, // max
+                    200, // default
+                    0, // decimals
+                    _position, // radius center position
+                    [1, 0, 0, 0.5] // radius colour
+                ],
+                false
+            ],
+            ["SLIDER:RADIUS", ["STR_tts_beam_moduleBeamStrike_damageRadius", "STR_tts_beam_moduleBeamStrike_damageRadius_desc"],
+                [ // control args
+                    1, // min
+                    2000, // max
+                    400, // default
+                    0, // decimals
+                    _position, // radius center position
+                    [0, 1, 0, 0.5] // radius colour
+                ],
+                false
+            ],
             ["EDIT", ["STR_tts_beam_moduleOrbitalBombardment_radius", "STR_tts_beam_moduleOrbitalBombardment_radius_desc"],
                 [ // control args
                     "200", // default text
@@ -68,7 +90,7 @@
         ],
         { // code run on dialog closed (only run if OK is clicked)
             params ["_dialogResult", "_args"];
-            _dialogResult params ["_beamColourPreset", "_customBeamColour", "_debrisColourPreset", "_customDebrisColour", "_disableDamage", "_radius", "_strikeCount", "_shotDelay", "_rainbow", "_stopBombardment"];
+            _dialogResult params ["_beamColourPreset", "_customBeamColour", "_debrisColourPreset", "_customDebrisColour", "_disableDamage", "_lethalRadius", "_damageRadius", "_radius", "_strikeCount", "_shotDelay", "_rainbow", "_stopBombardment"];
             _args params ["_position"];
 
             if (_stopBombardment) exitWith {
@@ -94,7 +116,7 @@
                 _debrisColour = _debrisColourPreset call tts_beam_fnc_colourFromString;
             };
 
-            [_position, _beamColour, _debrisColour, !_disableDamage, _radius, _strikeCount, _shotDelay, _rainbow] remoteExec ["tts_beam_fnc_orbitalBombardment", 2, false];
+            [_position, _beamColour, _debrisColour, !_disableDamage, _lethalRadius, _damageRadius, _radius, _strikeCount, _shotDelay, _rainbow] remoteExec ["tts_beam_fnc_orbitalBombardment", 2, false];
 
         }, {}, [_position] // args
     ] call zen_dialog_fnc_create;

--- a/stringtable.xml
+++ b/stringtable.xml
@@ -6,6 +6,112 @@
             <English>Default</English>
         </Key>
     </Package >
+    <Package name="Settings categories">
+        <Key ID="STR_tts_beam_settingsCat_misc">
+            <Original>Misc</Original>
+            <English>Misc</English>
+        </Key>
+        <Key ID="STR_tts_beam_settingsCat_effects">
+            <Original>Effects</Original>
+            <English>Effects</English>
+        </Key>
+        <Key ID="STR_tts_beam_settingsCat_cleanup">
+            <Original>Garbage Cleanup</Original>
+            <English>Garbage Cleanup</English>
+        </Key>
+    </Package >
+    <Package name="Settings">
+        <Container name="Vaporise bodies setting">
+            <Key ID="STR_tts_beam_settings_vaporiseBodies">
+                <Original>Vaporise bodies</Original>
+                <English>Vaporise bodies</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_vaporiseBodies_desc">
+                <Original>If enabled, infantry units inside the lethal radius of the laser will be vaporised</Original>
+                <English>If enabled, infantry units inside the lethal radius of the laser will be vaporised</English>
+            </Key>
+        </Container>
+        <Container name="Structure fires setting">
+            <Key ID="STR_tts_beam_settings_structureFiresEnabled">
+                <Original>Structure fires</Original>
+                <English>Structure fires</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_structureFiresEnabled_desc">
+                <Original>If enabled, structures inside the lethal radius of the laser will sometimes burn for a short amount of time</Original>
+                <English>If enabled, structures inside the lethal radius of the laser will sometimes burn for a short amount of time</English>
+            </Key>
+        </Container>
+        <Container name="Create craters setting">
+            <Key ID="STR_tts_beam_settings_createCraters">
+                <Original>Create craters</Original>
+                <English>Create craters</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_createCraters_desc">
+                <Original>If enabled, laser impacts will leave craters and scorch marks</Original>
+                <English>If enabled, laser impacts will leave craters and scorch marks</English>
+            </Key>
+        </Container>
+        <Container name="Structure fire chance setting">
+            <Key ID="STR_tts_beam_settings_structureFireChance">
+                <Original>Structure fire chance</Original>
+                <English>Structure fire chance</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_structureFireChance_desc">
+                <Original>The chance that a structure will catch fire when destroyed by the beam. Lots of fires can cause significant framerate drops</Original>
+                <English>The chance that a structure will catch fire when destroyed by the beam. Lots of fires can cause significant framerate drops</English>
+            </Key>
+        </Container>
+        <Container name="Structure fire duration min setting">
+            <Key ID="STR_tts_beam_settings_structureFireDurationMin">
+                <Original>Minimum structure fire duration</Original>
+                <English>Minimum structure fire duration</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_structureFireDurationMin_desc">
+                <Original>The minimum duration in seconds that fires started by the laser will burn for</Original>
+                <English>The minimum duration in seconds that fires started by the laser will burn for</English>
+            </Key>
+        </Container>
+        <Container name="Structure fire duration max setting">
+            <Key ID="STR_tts_beam_settings_structureFireDurationMax">
+                <Original>Maximum structure fire duration</Original>
+                <English>Maximum structure fire duration</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_structureFireDurationMax_desc">
+                <Original>The maximum duration in seconds that fires started by the laser will burn for</Original>
+                <English>The maximum duration in seconds that fires started by the laser will burn for</English>
+            </Key>
+        </Container>
+        <Container name="Cleanup skeletons setting">
+            <Key ID="STR_tts_beam_settings_cleanupSkeletons">
+                <Original>Cleanup skeletons</Original>
+                <English>Cleanup skeletons</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_cleanupSkeletons_desc">
+                <Original>If enabled, skeletons and scorch marks created when a unit is vaporised will be deleted after the cleanup timer runs out</Original>
+                <English>If enabled, skeletons and scorch marks created when a unit is vaporised will be deleted after the cleanup timer runs out</English>
+            </Key>
+        </Container>
+        <Container name="Cleanup skeletons delay setting">
+            <Key ID="STR_tts_beam_settings_cleanupSkeletonsDelay">
+                <Original>Skeleton cleanup delay</Original>
+                <English>Skeleton cleanup delay</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_cleanupSkeletonsDelay_desc">
+                <Original>Delay in seconds after a unit is vaporised before skeletons and scorch marks are deleted</Original>
+                <English>Delay in seconds after a unit is vaporised before skeletons and scorch marks are deleted</English>
+            </Key>
+        </Container>
+        <Container name="Disable impact flash setting">
+            <Key ID="STR_tts_beam_settings_disableImpactFlash">
+                <Original>Disable impact flash</Original>
+                <English>Disable impact flash</English>
+            </Key>
+            <Key ID="STR_tts_beam_settings_disableImpactFlash_desc">
+                <Original>Disables white flash effect on laser impact</Original>
+                <English>Disables white flash effect on laser impact</English>
+            </Key>
+        </Container>
+    </Package >
     <Package name="Modules">
         <Container name="Beam Strike Module">	
             <Key ID="STR_tts_beam_moduleBeamStrike_title">
@@ -104,6 +210,26 @@
                 <Key ID="STR_tts_beam_moduleBeamStrike_disableBeamDamage_desc">
                     <Original>If checked, beam will not damage units or destroy objects</Original>
                     <English>If checked, beam will not damage units or destroy objects</English>
+                </Key>
+            </Container>
+            <Container name="Lethal radius">
+                <Key ID="STR_tts_beam_moduleBeamStrike_lethalRadius">
+                    <Original>Lethal radius</Original>
+                    <English>Lethal radius</English>
+                </Key>
+                <Key ID="STR_tts_beam_moduleBeamStrike_lethalRadius_desc">
+                    <Original>The maximum distance in metres from the impact point that units/objects will recieve lethal damage</Original>
+                    <English>The maximum distance in metres from the impact point that units/objects will recieve lethal damage</English>
+                </Key>
+            </Container>
+            <Container name="Damage radius">
+                <Key ID="STR_tts_beam_moduleBeamStrike_damageRadius">
+                    <Original>Damage radius</Original>
+                    <English>Damage radius</English>
+                </Key>
+                <Key ID="STR_tts_beam_moduleBeamStrike_damageRadius_desc">
+                    <Original>The maximum distance in metres from the impact point that units/objects will recieve damage</Original>
+                    <English>The maximum distance in metres from the impact point that units/objects will recieve damage</English>
                 </Key>
             </Container>
         </Container>


### PR DESCRIPTION
New features:
- Added lethal radius and damage radius parameters to `fn_beam`.
- Added 'Lethal radius' and 'Damage radius' sliders to 'Beam Laser Strike' and 'Orbital Bombardment' ZEN modules.
- Infantry units within the lethal radius of the laser will now be vaporised.
- Structures within the lethal radius of the laser now have a chance to catch fire.
- A crater is created when the beam impacts terrain.
- Implemented CBA settings support. The script now requires CBA.
- Added various CBA settings to customise/disable newly added features.

Effect tweaks:
- Destroyed objects within the lethal radius no longer have damage effects to prevent large lag spikes when destroying lots of buildings.
- Added a shockwave particle on beam impact.
- Camera shake is now applied up to 2km away and lowers in intensity the further away the player is.
- The bright flash on beam impact is now only shown when the player is within 2km and looking towards the impact point.
- Camera shake, flash and blur effects are no longer shown in spectator mode or while using the Zeus interface.
- Explosion particles are now created from the laser impact point instead of the terrain beneath it.

Misc:
- The script now checks for 'ace_medical' rather than 'ace_main' so it should work for versions of ACE that have medical functions removed.
- Fixed a bug where the laser could sometimes get deflected in strange directions when bouncing off buildings.